### PR TITLE
fix: add int model for page_history to get only most recent record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_linkedin_pages v0.1.1
+- Added an intermediate table that filters the most recent records for `ugc_post_history` to avoid duplicate rows.
+
 # dbt_linkedin_pages v0.1.0
 
 The original release! The main focus of the package is to transform the core social media object tables into analytics-ready models that can be easily unioned in to other social media platform packages to get a single view. This is especially easy using our [Social Media Reporting package](https://github.com/fivetran/dbt_social_media_reporting).

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'linkedin_pages'
-version: '0.1.0'
+version: '0.1.1'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'linkedin_pages_source_integration_tests'
-version: '0.1.0'
+version: '0.1.1'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/intermediate/int_linkedin_pages__latest_post_history.sql
+++ b/models/intermediate/int_linkedin_pages__latest_post_history.sql
@@ -1,0 +1,16 @@
+with ugc_post_history as (
+
+    select *
+    from {{ var('ugc_post_history_staging') }}
+
+), is_most_recent as (
+
+    select
+        *,
+        row_number() over (partition by ugc_post_id, source_relation order by last_modified_timestamp desc) = 1 as is_most_recent_record
+    from ugc_post_history
+
+)
+
+select *
+from is_most_recent

--- a/models/linkedin_pages__posts.sql
+++ b/models/linkedin_pages__posts.sql
@@ -16,7 +16,8 @@ ugc_post_share_statistic as (
 ugc_post_history as (
 
     select *
-    from {{ var('ugc_post_history_staging') }}
+    from {{ ref('int_linkedin_pages__latest_post_history') }}
+    where is_most_recent_record = true
 
 ),
 
@@ -43,7 +44,7 @@ organization_ugc_post as (
 
 joined as (
 
-    select 
+    select
         ugc_post_history.ugc_post_id,
         ugc_post_history.post_author,
         ugc_post_history.post_url,


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Simon Stepper, Analytics Lead, Capdesk

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
Resolves https://github.com/fivetran/dbt_linkedin_pages/issues/3
We add a new int model that selects only the most recent row for each post in `ugc_post_history`. This avoids duplicate rows in `linkedin_pages__posts`

**Who will benefit from the change(s) within this PR?** 
<!--- Describe who will benefit from the change(s). -->
All customers that edit posts on linkedin

**Did you update the CHANGELOG?** 
<!--- Please update the package relevant CHANGELOG detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Did you update the README (If needed)?** 
<!--- If any variables were add or a completely new feature was integrated, be sure to update the README accordingly. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes
- [x] No (Not Applicable)

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide explanation how the change is non breaking below.)
We're only making sure that data is behaving as it is intended by the package and fix an edge case that can cause duplicated rows

**Did you update the dbt_project.yml files with the version upgrade??** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Issue or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature https://github.com/fivetran/dbt_linkedin_pages/issues/3
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other (please provide additional testing details below)
Added to test to our local dbt project. Tests run fine and resulting data looks as it should and reconciles with the LinkedIn Dashboard

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🏔️ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
